### PR TITLE
Support de fileName pour le generatePath.

### DIFF
--- a/Kronos/FileSystem/FileSystem.php
+++ b/Kronos/FileSystem/FileSystem.php
@@ -45,7 +45,7 @@ class FileSystem implements FileSystemInterface {
 		$mount = $this->mountSelector->getImportationMount();
 		$fileUuid = $this->fileRepository->addNewFile($mount->getMountType(),$fileName);
 
-		if(!$mount->put($fileUuid,$filePath)){
+		if(!$mount->put($fileUuid,$filePath, $fileName)){
 			$this->fileRepository->delete($fileUuid);
 			throw new FileCantBeWrittenException($mount->getMountType());
 		}
@@ -55,39 +55,42 @@ class FileSystem implements FileSystemInterface {
 
 	/**
 	 * @param int $id
+	 * @param $fileName
 	 * @return File
 	 */
-	public function get($id){
+	public function get($id, $fileName){
 		$mount = $this->getMountForId($id);
 
-		$file = $mount->get($id);
-		$file->metadata = $this->getMetadata($id);
+		$file = $mount->get($id, $fileName);
+		$file->metadata = $this->getMetadata($id, $fileName);
 
 		return $file;
 	}
 
 	/**
 	 * @param int $id
+	 * @param $fileName
 	 * @return string
 	 * @throws MountNotFoundException
 	 */
-	public function getDownloadableLink($id){
+	public function getDownloadableLink($id, $fileName){
 		$mount = $this->getMountForId($id);
-		$signedUrl = $mount->getSignedUrl($id);
+		$signedUrl = $mount->getSignedUrl($id, $fileName);
 		return $signedUrl;
 	}
 
 
 	/**
 	 * @param int $id
+	 * @param $fileName
 	 * @return Metadata
 	 * @throws MountNotFoundException
 	 */
-	public function getMetadata($id){
+	public function getMetadata($id, $fileName){
 		$mount = $this->getMountForId($id);
 		$fileName = $this->fileRepository->getFileName($id);
 
-		$metadata = $mount->getMetadata($id);
+		$metadata = $mount->getMetadata($id, $fileName);
 		$metadata->name = $fileName;
 
 		return $this->metadataTranslator->translateInternalToExposed($metadata);
@@ -95,20 +98,22 @@ class FileSystem implements FileSystemInterface {
 
 	/**
 	 * @param int $id
+	 * @param $fileName
 	 * @throws FileNotFoundException
 	 */
-	public function delete($id){
+	public function delete($id, $fileName){
 		$mount = $this->getMountForId($id);
-		$mount->delete($id);
+		$mount->delete($id, $fileName);
 	}
 
 	/**
 	 * @param int $id
+	 * @param $fileName
 	 * @throws MountNotFoundException
 	 */
-	public function retrieve($id) {
+	public function retrieve($id, $fileName) {
 		$mount = $this->getMountForId($id);
-		$mount->retrieve($id);
+		$mount->retrieve($id, $fileName);
 	}
 
 	/**

--- a/Kronos/FileSystem/FileSystemInterface.php
+++ b/Kronos/FileSystem/FileSystemInterface.php
@@ -14,33 +14,33 @@ interface FileSystemInterface {
 	 * @return int
 	 * @throws FileCantBeWrittenException
 	 */
-	public function put($filePath,$fileName);
+	public function put($filePath, $fileName);
 
 	/**
 	 * @param int $id
 	 * @return File
 	 */
-	public function get($id);
+	public function get($id, $fileName);
 
 	/**
 	 * @param int $id
 	 * @return string
 	 */
-	public function getDownloadableLink($id);
+	public function getDownloadableLink($id, $fileName);
 
 	/**
 	 * @param int $id
 	 * @return Metadata
 	 */
-	public function getMetadata($id);
+	public function getMetadata($id, $fileName);
 
 	/**
 	 * @param int $id
 	 */
-	public function delete($id);
+	public function delete($id, $fileName);
 
 	/**
 	 * @param int $id
 	 */
-	public function retrieve($id);
+	public function retrieve($id, $fileName);
 }

--- a/Kronos/FileSystem/Mount/FlySystemBaseMount.php
+++ b/Kronos/FileSystem/Mount/FlySystemBaseMount.php
@@ -40,10 +40,11 @@ abstract class FlySystemBaseMount implements MountInterface{
 
 	/**
 	 * @param string $uuid
+	 * @param $fileName
 	 * @return File
 	 */
-	public function get($uuid) {
-		$path = $this->pathGenerator->generatePath($uuid);
+	public function get($uuid, $fileName) {
+		$path = $this->pathGenerator->generatePath($uuid, $fileName);
 		$flySystemFile = $this->mount->get($path);
 		return new File($flySystemFile);
 	}
@@ -53,31 +54,42 @@ abstract class FlySystemBaseMount implements MountInterface{
 	 *
 	 * @param string $uuid
 	 * @param string $filePath
+	 * @param $fileName
 	 * @return bool
 	 */
-	public function put($uuid, $filePath) {
-		$path = $this->pathGenerator->generatePath($uuid);
+	public function put($uuid, $filePath, $fileName) {
+		$path = $this->pathGenerator->generatePath($uuid, $fileName);
 		return $this->mount->put($path,$this->getFileContent($filePath));
 	}
 
 	/**
+	 *
 	 * Delete a file.
 	 *
 	 * @param string $uuid
-	 *
+	 * @param $fileName
 	 * @return bool
 	 */
-	public function delete($uuid) {
-		$path = $this->pathGenerator->generatePath($uuid);
+	public function delete($uuid, $fileName) {
+		$path = $this->pathGenerator->generatePath($uuid, $fileName);
 		return $this->mount->delete($path);
 
 	}
 
 	/**
-	 * @return string
+	 * @return mixed
 	 */
 	public function getMountType() {
 		return static::MOUNT_TYPE;
+	}
+
+	/**
+	 * @param string $uuid
+	 * @param $fileName
+	 * @return string
+	 */
+	public function getPath($uuid, $fileName) {
+		return $this->pathGenerator->generatePath($uuid, $fileName);
 	}
 
 	/**

--- a/Kronos/FileSystem/Mount/Local/Local.php
+++ b/Kronos/FileSystem/Mount/Local/Local.php
@@ -24,26 +24,29 @@ class Local extends FlySystemBaseMount {
 
 	/**
 	 * @param string $uuid
+	 * @param $fileName
 	 * @return string
 	 */
-	public function getSignedUrl($uuid) {
+	public function getSignedUrl($uuid, $fileName) {
 		return self::SIGNED_URL_BASE_PATH . $uuid;
 	}
 
 	/**
 	 * @param string $uuid
+	 * @param $fileName
 	 * @throws CantRetreiveFileException
 	 */
-	public function retrieve($uuid) {
+	public function retrieve($uuid, $fileName) {
 		throw new CantRetreiveFileException($uuid);
 	}
 
 	/**
 	 * @param string $uuid
-	 * @return Metadata|false
+	 * @param $fileName
+	 * @return bool|Metadata
 	 */
-	public function getMetadata($uuid) {
-		$path = $this->pathGenerator->generatePath($uuid);
+	public function getMetadata($uuid, $fileName) {
+		$path = $this->pathGenerator->generatePath($uuid, $fileName);
 
 		if($localMetadata = $this->mount->getMetadata($path)) {
 			$metadata = new Metadata();

--- a/Kronos/FileSystem/Mount/MountInterface.php
+++ b/Kronos/FileSystem/Mount/MountInterface.php
@@ -15,44 +15,50 @@ interface MountInterface {
 	 * @param string $uuid
 	 * @return File
 	 */
-	public function get($uuid);
+	public function get($uuid, $fileName);
 
 	/**
 	 * @param string $uuid
 	 * @return string
 	 */
-	public function getSignedUrl($uuid);
+	public function getSignedUrl($uuid, $fileName);
 
 	/**
 	 * Delete a file.
 	 *
 	 * @param string $uuid
 	 */
-	public function delete($uuid);
+	public function delete($uuid, $fileName);
 
 
 	/**
 	 * Write a new file using a stream.
 	 *
-	 * @param string $uuid
-	 * @param string $filePath
-	 * @return bool
-	 * @internal param resource $resource
+	 * @param $uuid
+	 * @param $filePath
+	 * @param $fileName
+	 * @return mixed
 	 *
 	 */
-	public function put($uuid, $filePath);
+	public function put($uuid, $filePath, $fileName);
 
 	/**
 	 * @param string $uuid
 	 * @throws CantRetreiveFileException
 	 */
-	public function retrieve($uuid);
+	public function retrieve($uuid, $fileName);
+
+	/**
+	 * @param string $uuid
+	 * @return mixed
+	 */
+	public function getPath($uuid, $fileName);
 
 	/**
 	 * @param string $uuid
 	 * @return Metadata
 	 */
-	public function getMetadata($uuid);
+	public function getMetadata($uuid, $fileName);
 
 	/**
 	 * @return string

--- a/Kronos/FileSystem/Mount/PathGeneratorInterface.php
+++ b/Kronos/FileSystem/Mount/PathGeneratorInterface.php
@@ -5,8 +5,9 @@ namespace Kronos\FileSystem\Mount;
 interface PathGeneratorInterface {
 
 	/**
-	 * @param string $uuid
-	 * @return string
+	 * @param $uuid
+	 * @param $fileName
+	 * @return mixed
 	 */
-	public function generatePath($uuid);
+	public function generatePath($uuid, $fileName);
 }

--- a/Kronos/FileSystem/Mount/S3/S3.php
+++ b/Kronos/FileSystem/Mount/S3/S3.php
@@ -26,14 +26,15 @@ class S3 extends FlySystemBaseMount {
 
 	/**
 	 * @param string $uuid
+	 * @param $fileName
 	 * @return string
 	 */
-	public function getSignedUrl($uuid) {
+	public function getSignedUrl($uuid, $fileName) {
 		/** @var AwsS3Adapter $awsS3Adaptor */
 		$awsS3Adaptor = $this->mount->getAdapter();
 		$s3Client = $awsS3Adaptor->getClient();
 
-		$path = $this->pathGenerator->generatePath($uuid);
+		$path = $this->pathGenerator->generatePath($uuid, $fileName);
 		$location = $awsS3Adaptor->applyPathPrefix($path);
 
 		$command = $s3Client->getCommand(
@@ -52,14 +53,15 @@ class S3 extends FlySystemBaseMount {
 
 	/**
 	 * @param string $uuid
+	 * @param $fileName
 	 * @throws CantRetreiveFileException
 	 */
-	public function retrieve($uuid) {
+	public function retrieve($uuid, $fileName) {
 		/** @var AwsS3Adapter $awsS3Adaptor */
 		$awsS3Adaptor = $this->mount->getAdapter();
 		$s3Client = $awsS3Adaptor->getClient();
 
-		$path = $this->pathGenerator->generatePath($uuid);
+		$path = $this->pathGenerator->generatePath($uuid, $fileName);
 		$location = $awsS3Adaptor->applyPathPrefix($path);
 
 		try {
@@ -86,10 +88,11 @@ class S3 extends FlySystemBaseMount {
 
 	/**
 	 * @param string $uuid
-	 * @return Metadata|false
+	 * @param $fileName
+	 * @return bool|Metadata
 	 */
-	public function getMetadata($uuid) {
-		$path = $this->pathGenerator->generatePath($uuid);
+	public function getMetadata($uuid, $fileName) {
+		$path = $this->pathGenerator->generatePath($uuid, $fileName);
 
 		if($s3Metadata = $this->mount->getMetadata($path)) {
 			$metadata = new Metadata();

--- a/tests/Kronos/Tests/FileSystem/FileSystemTest.php
+++ b/tests/Kronos/Tests/FileSystem/FileSystemTest.php
@@ -152,7 +152,7 @@ class FileSystemTest extends PHPUnit_Framework_TestCase{
 			->method('getFileMountType')
 			->with(self::UUID);
 
-		$this->fileSystem->getDownloadableLink(self::UUID);
+		$this->fileSystem->getDownloadableLink(self::UUID, self::FILE_NAME);
 	}
 
 	public function test_mountType_getDownloadableLink_shouldSelectMount(){
@@ -164,7 +164,7 @@ class FileSystemTest extends PHPUnit_Framework_TestCase{
 			->with(self::MOUNT_TYPE)
 			->willReturn($this->mount);
 
-		$this->fileSystem->getDownloadableLink(self::UUID);
+		$this->fileSystem->getDownloadableLink(self::UUID, self::FILE_NAME);
 	}
 
 	public function test_mountSelected_getDownloadableLink_getSignedUrl(){
@@ -175,7 +175,7 @@ class FileSystemTest extends PHPUnit_Framework_TestCase{
 			->method('getSignedUrl')
 			->with(self::UUID);
 
-		$this->fileSystem->getDownloadableLink(self::UUID);
+		$this->fileSystem->getDownloadableLink(self::UUID, self::FILE_NAME);
 	}
 
 	public function test_mountCouldNotHaveBeenSelected_getDownloadableLink_shouldThrowMountNotFoundException(){
@@ -184,7 +184,7 @@ class FileSystemTest extends PHPUnit_Framework_TestCase{
 
 		$this->expectException(MountNotFoundException::class);
 
-		$this->fileSystem->getDownloadableLink(self::UUID);
+		$this->fileSystem->getDownloadableLink(self::UUID, self::FILE_NAME);
 	}
 
 	public function test_signedUlr_getDownloadableLink_shouldReturnSignedUlr(){
@@ -192,7 +192,7 @@ class FileSystemTest extends PHPUnit_Framework_TestCase{
 
 		$this->mount->method('getSignedUrl')->willReturn(self::A_SIGNED_URL);
 
-		$actualSignedUrl = $this->fileSystem->getDownloadableLink(self::UUID);
+		$actualSignedUrl = $this->fileSystem->getDownloadableLink(self::UUID, self::FILE_NAME);
 
 		self::assertSame(self::A_SIGNED_URL,$actualSignedUrl);
 	}
@@ -205,7 +205,7 @@ class FileSystemTest extends PHPUnit_Framework_TestCase{
 			->method('getFileMountType')
 			->with(self::UUID);
 
-		$this->fileSystem->delete(self::UUID);
+		$this->fileSystem->delete(self::UUID, self::FILE_NAME);
 	}
 
 	public function test_mountType_delete_shouldSelectMount(){
@@ -217,7 +217,7 @@ class FileSystemTest extends PHPUnit_Framework_TestCase{
 			->with(self::MOUNT_TYPE)
 			->willReturn($this->mount);
 
-		$this->fileSystem->delete(self::UUID);
+		$this->fileSystem->delete(self::UUID, self::FILE_NAME);
 	}
 
 	public function test_mountCouldNotHaveBeenSelected_delete_shouldThrowMountNotFoundException(){
@@ -226,7 +226,7 @@ class FileSystemTest extends PHPUnit_Framework_TestCase{
 
 		$this->expectException(MountNotFoundException::class);
 
-		$this->fileSystem->delete(self::UUID);
+		$this->fileSystem->delete(self::UUID, self::FILE_NAME);
 	}
 
 	public function test_mountSelected_delete_delete(){
@@ -237,7 +237,7 @@ class FileSystemTest extends PHPUnit_Framework_TestCase{
 			->method('delete')
 			->with(self::UUID);
 
-		$this->fileSystem->delete(self::UUID);
+		$this->fileSystem->delete(self::UUID, self::FILE_NAME);
 	}
 
 	public function test_givenId_retrieve_shouldMountAssociatedWithId(){
@@ -248,7 +248,7 @@ class FileSystemTest extends PHPUnit_Framework_TestCase{
 			->method('getFileMountType')
 			->with(self::UUID);
 
-		$this->fileSystem->retrieve(self::UUID);
+		$this->fileSystem->retrieve(self::UUID, self::FILE_NAME);
 	}
 
 	public function test_mountType_retrieve_shouldSelectMount(){
@@ -260,7 +260,7 @@ class FileSystemTest extends PHPUnit_Framework_TestCase{
 			->with(self::MOUNT_TYPE)
 			->willReturn($this->mount);
 
-		$this->fileSystem->retrieve(self::UUID);
+		$this->fileSystem->retrieve(self::UUID, self::FILE_NAME);
 	}
 
 	public function test_mountCouldNotHaveBeenSelected_retrieve_shouldThrowMountNotFoundException(){
@@ -268,7 +268,7 @@ class FileSystemTest extends PHPUnit_Framework_TestCase{
 
 		$this->expectException(MountNotFoundException::class);
 
-		$this->fileSystem->retrieve(self::UUID);
+		$this->fileSystem->retrieve(self::UUID, self::FILE_NAME);
 	}
 
 	public function test_mount_retrieve_retreive(){
@@ -279,7 +279,7 @@ class FileSystemTest extends PHPUnit_Framework_TestCase{
 			->method('retrieve')
 			->with(self::UUID);
 
-		$this->fileSystem->retrieve(self::UUID);
+		$this->fileSystem->retrieve(self::UUID, self::FILE_NAME);
 	}
 
 	public function test_givenId_getMetadata_shouldMountAssociatedWithId(){
@@ -294,7 +294,7 @@ class FileSystemTest extends PHPUnit_Framework_TestCase{
 			->method('getFileMountType')
 			->with(self::UUID);
 
-		$this->fileSystem->getMetadata(self::UUID);
+		$this->fileSystem->getMetadata(self::UUID, self::FILE_NAME);
 	}
 
 	public function test_mountType_getMetadata_shouldSelectMount(){
@@ -308,7 +308,7 @@ class FileSystemTest extends PHPUnit_Framework_TestCase{
 			->with(self::MOUNT_TYPE)
 			->willReturn($this->mount);
 
-		$this->fileSystem->getMetadata(self::UUID);
+		$this->fileSystem->getMetadata(self::UUID, self::FILE_NAME);
 	}
 
 	public function test_mountCouldNotHaveBeenSelected_getMetadata_shouldThrowMountNotFoundException(){
@@ -316,7 +316,7 @@ class FileSystemTest extends PHPUnit_Framework_TestCase{
 
 		$this->expectException(MountNotFoundException::class);
 
-		$this->fileSystem->getMetadata(self::UUID);
+		$this->fileSystem->getMetadata(self::UUID, self::FILE_NAME);
 	}
 
 	public function test_mount_getMetadata_getMetadata(){
@@ -329,7 +329,7 @@ class FileSystemTest extends PHPUnit_Framework_TestCase{
 			->method('getMetadata')
 			->with(self::UUID);
 
-		$this->fileSystem->getMetadata(self::UUID);
+		$this->fileSystem->getMetadata(self::UUID, self::FILE_NAME);
 	}
 
 	public function test_metadata_getMetadata_ShouldGetFileName(){
@@ -342,7 +342,7 @@ class FileSystemTest extends PHPUnit_Framework_TestCase{
 			->method('getFileName')
 			->with(self::UUID);
 
-		$this->fileSystem->getMetadata(self::UUID);
+		$this->fileSystem->getMetadata(self::UUID, self::FILE_NAME);
 	}
 
 	public function test_InternalMetadata_getMetadata_ShouldTranslateMetadata(){
@@ -355,7 +355,7 @@ class FileSystemTest extends PHPUnit_Framework_TestCase{
 			->method('translateInternalToExposed')
 			->with($this->metadata);
 
-		$this->fileSystem->getMetadata(self::UUID);
+		$this->fileSystem->getMetadata(self::UUID, self::FILE_NAME);
 	}
 
 	public function test_mount_getMetadata_ShouldReturnMetadata(){
@@ -363,7 +363,7 @@ class FileSystemTest extends PHPUnit_Framework_TestCase{
 		$this->mountSelector->method('selectMount')->willReturn($this->mount);
 		$this->mount->method('getMetadata')->willReturn($this->metadata);
 
-		$actualMetadata = $this->fileSystem->getMetadata(self::UUID);
+		$actualMetadata = $this->fileSystem->getMetadata(self::UUID, self::FILE_NAME);
 
 		self::assertSame($actualMetadata,$actualMetadata);
 	}
@@ -378,7 +378,7 @@ class FileSystemTest extends PHPUnit_Framework_TestCase{
 			->method('getFileMountType')
 			->with(self::UUID);
 
-		$this->fileSystem->get(self::UUID);
+		$this->fileSystem->get(self::UUID, self::FILE_NAME);
 	}
 
 	public function test_mountType_get_shouldSelectMount(){
@@ -391,7 +391,7 @@ class FileSystemTest extends PHPUnit_Framework_TestCase{
 			->with(self::MOUNT_TYPE)
 			->willReturn($this->mount);
 
-		$this->fileSystem->get(self::UUID);
+		$this->fileSystem->get(self::UUID, self::FILE_NAME);
 	}
 
 	public function test_mountCouldNotHaveBeenSelected_get_shouldThrowMountNotFoundException(){
@@ -400,7 +400,7 @@ class FileSystemTest extends PHPUnit_Framework_TestCase{
 
 		$this->expectException(MountNotFoundException::class);
 
-		$this->fileSystem->get(self::UUID);
+		$this->fileSystem->get(self::UUID, self::FILE_NAME);
 	}
 
 	public function test_mount_get_shouldGetFile(){
@@ -412,7 +412,7 @@ class FileSystemTest extends PHPUnit_Framework_TestCase{
 			->method('get')
 			->with(self::UUID);
 
-		$this->fileSystem->get(self::UUID);
+		$this->fileSystem->get(self::UUID, self::FILE_NAME);
 	}
 
 	public function test_mount_get_shouldGetMetadata(){
@@ -424,14 +424,14 @@ class FileSystemTest extends PHPUnit_Framework_TestCase{
 			->method('getMetadata')
 			->with(self::UUID);
 
-		$this->fileSystem->get(self::UUID);
+		$this->fileSystem->get(self::UUID, self::FILE_NAME);
 	}
 
 	public function test_File_get_shouldReturnFile(){
 		$this->givenWillReturnFile();
 		$this->mountSelector->method('selectMount')->willReturn($this->mount);
 
-		$this->file = $this->fileSystem->get(self::UUID);
+		$this->file = $this->fileSystem->get(self::UUID, self::FILE_NAME);
 
 		self::assertInstanceOf(File::class,$this->file);
 	}
@@ -441,7 +441,7 @@ class FileSystemTest extends PHPUnit_Framework_TestCase{
 		$this->givenWillReturnFile();
 		$this->mountSelector->method('selectMount')->willReturn($this->mount);
 
-		$file = $this->fileSystem->get(self::UUID);
+		$file = $this->fileSystem->get(self::UUID, self::FILE_NAME);
 
 		self::assertInstanceOf(\Kronos\FileSystem\File\Metadata::class,$file->metadata);
 	}

--- a/tests/Kronos/Tests/FileSystem/Mount/Local/LocalTest.php
+++ b/tests/Kronos/Tests/FileSystem/Mount/Local/LocalTest.php
@@ -13,6 +13,7 @@ class LocalTest extends PHPUnit_Framework_TestCase{
 
 	const UUID = 'UUID';
 	const A_PATH = 'A_PATH';
+	const A_FILE_NAME = 'A_FILE_NAME';
 	const A_FILE_PATH = 'A_FILE_PATH';
 	const A_LOCATION = 'A_LOCATION';
 	const AN_URI = 'AN_URI';
@@ -54,7 +55,7 @@ class LocalTest extends PHPUnit_Framework_TestCase{
 			->method('generatePath')
 			->with(self::UUID);
 
-		$this->localMount->get(self::UUID);
+		$this->localMount->get(self::UUID, self::A_FILE_NAME);
 	}
 
 	public function test_path_get_shouldReadStream(){
@@ -66,13 +67,13 @@ class LocalTest extends PHPUnit_Framework_TestCase{
 			->method('get')
 			->with(self::A_PATH);
 
-		$this->localMount->get(self::UUID);
+		$this->localMount->get(self::UUID, self::A_FILE_NAME);
 	}
 
 	public function test_stream_get_shouldReturnStream(){
 		$this->fileSystem->method('get')->willReturn($this->getMockWithoutInvokingTheOriginalConstructor(File::class));
 
-		$file = $this->localMount->get(self::UUID);
+		$file = $this->localMount->get(self::UUID, self::A_FILE_NAME);
 
 		$this->assertInstanceOf(\Kronos\FileSystem\File\File::class,$file);
 	}
@@ -83,7 +84,7 @@ class LocalTest extends PHPUnit_Framework_TestCase{
 			->method('generatePath')
 			->with(self::UUID);
 
-		$this->localMount->delete(self::UUID);
+		$this->localMount->delete(self::UUID, self::A_FILE_NAME);
 	}
 
 	public function test_path_delete_shouldDeleteFile(){
@@ -94,14 +95,14 @@ class LocalTest extends PHPUnit_Framework_TestCase{
 			->method('delete')
 			->with(self::A_PATH);
 
-		$this->localMount->delete(self::UUID);
+		$this->localMount->delete(self::UUID, self::A_FILE_NAME);
 	}
 
 	public function test_FileDeleted_delete_shouldReturnTrue(){
 
 		$this->fileSystem->method('delete')->willReturn(true);
 
-		$deleted = $this->localMount->delete(self::UUID);
+		$deleted = $this->localMount->delete(self::UUID, self::A_FILE_NAME);
 
 		$this->assertTrue($deleted);
 	}
@@ -110,7 +111,7 @@ class LocalTest extends PHPUnit_Framework_TestCase{
 
 		$this->fileSystem->method('delete')->willReturn(false);
 
-		$deleted = $this->localMount->delete(self::UUID);
+		$deleted = $this->localMount->delete(self::UUID, self::A_FILE_NAME);
 
 		$this->assertFalse($deleted);
 	}
@@ -121,7 +122,7 @@ class LocalTest extends PHPUnit_Framework_TestCase{
 			->method('generatePath')
 			->with(self::UUID);
 
-		$this->localMount->put(self::UUID,self::A_FILE_PATH);
+		$this->localMount->put(self::UUID,self::A_FILE_PATH, self::A_FILE_NAME);
 	}
 
 	public function test_path_put_shouldPut(){
@@ -132,14 +133,14 @@ class LocalTest extends PHPUnit_Framework_TestCase{
 			->method('put')
 			->with(self::A_PATH,localMountTestable::A_FILE_CONTENT);
 
-		$this->localMount->put(self::UUID,self::A_FILE_PATH);
+		$this->localMount->put(self::UUID,self::A_FILE_PATH, self::A_FILE_NAME);
 	}
 
 	public function test_FileWritten_put_shouldReturnTrue(){
 
 		$this->fileSystem->method('put')->willReturn(true);
 
-		$written = $this->localMount->put(self::UUID,self::A_FILE_PATH);
+		$written = $this->localMount->put(self::UUID,self::A_FILE_PATH, self::A_FILE_NAME);
 
 		$this->assertTrue($written);
 	}
@@ -148,7 +149,7 @@ class LocalTest extends PHPUnit_Framework_TestCase{
 
 		$this->fileSystem->method('put')->willReturn(false);
 
-		$written = $this->localMount->put(self::UUID,self::A_FILE_PATH);
+		$written = $this->localMount->put(self::UUID,self::A_FILE_PATH, self::A_FILE_NAME);
 
 		$this->assertFalse($written);
 	}
@@ -165,7 +166,7 @@ class LocalTest extends PHPUnit_Framework_TestCase{
 			->method('generatePath')
 			->with(self::UUID);
 
-		$this->localMount->getMetadata(self::UUID);
+		$this->localMount->getMetadata(self::UUID, self::A_FILE_NAME);
 	}
 
 	public function test_path_getMetadata_shouldDeleteFile(){
@@ -176,14 +177,14 @@ class LocalTest extends PHPUnit_Framework_TestCase{
 			->method('getMetadata')
 			->with(self::A_PATH);
 
-		$this->localMount->getMetadata(self::UUID);
+		$this->localMount->getMetadata(self::UUID, self::A_FILE_NAME);
 	}
 
 	public function test_Path_getMetadata_shouldReturnMetadata(){
 
 		$this->fileSystem->method('getMetadata')->willReturn(['timestamp'=>0,'size'=>0]);
 
-		$metadata = $this->localMount->getMetadata(self::UUID);
+		$metadata = $this->localMount->getMetadata(self::UUID, self::A_FILE_NAME);
 
 		self::assertInstanceOf(Metadata::class,$metadata);
 	}
@@ -197,20 +198,20 @@ class LocalTest extends PHPUnit_Framework_TestCase{
 			->method('getMimeType')
 			->with(self::A_PATH);
 
-		$this->localMount->getMetadata(self::UUID);
+		$this->localMount->getMetadata(self::UUID, self::A_FILE_NAME);
 	}
 
 	public function test_FileNotWritten_getMetadata_shouldReturnFalse(){
 
 		$this->fileSystem->method('getMetadata')->willReturn(false);
 
-		$metadata = $this->localMount->getMetadata(self::UUID);
+		$metadata = $this->localMount->getMetadata(self::UUID, self::A_FILE_NAME);
 
 		$this->assertFalse($metadata);
 	}
 
 	public function test_uuid_getSignedUrl_shouldReturnPresignedUrl(){
-		$actualSignedUrl = $this->localMount->getSignedUrl(self::UUID);
+		$actualSignedUrl = $this->localMount->getSignedUrl(self::UUID, self::A_FILE_NAME);
 
 		self::assertEquals(\Kronos\FileSystem\Mount\Local\Local::SIGNED_URL_BASE_PATH.self::UUID,$actualSignedUrl);
 	}

--- a/tests/Kronos/Tests/FileSystem/Mount/S3/S3Test.php
+++ b/tests/Kronos/Tests/FileSystem/Mount/S3/S3Test.php
@@ -19,6 +19,7 @@ class S3Test extends PHPUnit_Framework_TestCase{
 
 	const UUID = 'UUID';
 	const A_PATH = 'A_PATH';
+	const A_FILE_NAME = 'A_FILE_NAME';
 	const A_FILE_PATH = 'A_FILE_PATH';
 	const A_LOCATION = 'A_LOCATION';
 	const S3_BUCKET = 'S3_BUCKET';
@@ -67,7 +68,7 @@ class S3Test extends PHPUnit_Framework_TestCase{
 			->method('generatePath')
 			->with(self::UUID);
 
-		$this->s3mount->get(self::UUID);
+		$this->s3mount->get(self::UUID, self::A_FILE_NAME);
 	}
 
 	public function test_path_get_shouldGet(){
@@ -79,13 +80,13 @@ class S3Test extends PHPUnit_Framework_TestCase{
 			->method('get')
 			->with(self::A_PATH);
 
-		$this->s3mount->get(self::UUID);
+		$this->s3mount->get(self::UUID, self::A_FILE_NAME);
 	}
 
 	public function test_stream_get_shouldReturnFile(){
 		$this->fileSystem->method('get')->willReturn($this->getMockWithoutInvokingTheOriginalConstructor(\League\Flysystem\File::class));
 
-		$file = $this->s3mount->get(self::UUID);
+		$file = $this->s3mount->get(self::UUID, self::A_FILE_NAME);
 
 		self::assertInstanceOf(File::class,$file);
 	}
@@ -99,7 +100,7 @@ class S3Test extends PHPUnit_Framework_TestCase{
 			->expects(self::once())
 			->method('getClient');
 
-		$this->s3mount->getSignedUrl(self::UUID);
+		$this->s3mount->getSignedUrl(self::UUID, self::A_FILE_NAME);
 	}
 
 	public function test_uuid_getSignedUrl_shouldGetPathOfFile(){
@@ -112,7 +113,7 @@ class S3Test extends PHPUnit_Framework_TestCase{
 			->method('generatePath')
 			->with(self::UUID);
 
-		$this->s3mount->getSignedUrl(self::UUID);
+		$this->s3mount->getSignedUrl(self::UUID, self::A_FILE_NAME);
 	}
 
 	public function test_path_getSignedUrl_shouldGetFileLocation(){
@@ -126,7 +127,7 @@ class S3Test extends PHPUnit_Framework_TestCase{
 			->method('applyPathPrefix')
 			->with(self::A_PATH);
 
-		$this->s3mount->getSignedUrl(self::UUID);
+		$this->s3mount->getSignedUrl(self::UUID, self::A_FILE_NAME);
 	}
 
 	public function test_location_getSignedUrl_shouldGetCommandToGetFile(){
@@ -147,7 +148,7 @@ class S3Test extends PHPUnit_Framework_TestCase{
 			)
 			->willReturn($this->getMockWithoutInvokingTheOriginalConstructor(CommandInterface::class));
 
-		$this->s3mount->getSignedUrl(self::UUID);
+		$this->s3mount->getSignedUrl(self::UUID, self::A_FILE_NAME);
 	}
 
 	public function test_command_getSignedUrl_shouldGetCommandToGetFile(){
@@ -161,7 +162,7 @@ class S3Test extends PHPUnit_Framework_TestCase{
 			->with($command,S3::PRESIGNED_URL_LIFE_TIME)
 			->willReturn($this->getMockWithoutInvokingTheOriginalConstructor(RequestInterface::class));
 
-		$this->s3mount->getSignedUrl(self::UUID);
+		$this->s3mount->getSignedUrl(self::UUID, self::A_FILE_NAME);
 	}
 
 	public function test_request_getSignedUrl_shouldGetUriFromRequest(){
@@ -174,7 +175,7 @@ class S3Test extends PHPUnit_Framework_TestCase{
 			->expects(self::once())
 			->method('getUri');
 
-		$this->s3mount->getSignedUrl(self::UUID);
+		$this->s3mount->getSignedUrl(self::UUID, self::A_FILE_NAME);
 	}
 
 	public function test_uri_getSignedUrl_shouldReturnUri(){
@@ -184,7 +185,7 @@ class S3Test extends PHPUnit_Framework_TestCase{
 		$this->s3Client->method('createPresignedRequest')->willReturn($request);
 		$request->method('getUri')->willReturn(self::AN_URI);
 
-		$actualUri = $this->s3mount->getSignedUrl(self::UUID);
+		$actualUri = $this->s3mount->getSignedUrl(self::UUID, self::A_FILE_NAME);
 
 		self::assertSame(self::AN_URI,$actualUri);
 	}
@@ -195,7 +196,7 @@ class S3Test extends PHPUnit_Framework_TestCase{
 			->method('generatePath')
 			->with(self::UUID);
 
-		$this->s3mount->put(self::UUID,self::A_FILE_PATH);
+		$this->s3mount->put(self::UUID,self::A_FILE_PATH, self::A_FILE_NAME);
 	}
 
 	public function test_path_put_shouldPut(){
@@ -206,14 +207,14 @@ class S3Test extends PHPUnit_Framework_TestCase{
 			->method('put')
 			->with(self::A_PATH,s3MountTestable::A_FILE_CONTENT);
 
-		$this->s3mount->put(self::UUID,self::A_FILE_PATH);
+		$this->s3mount->put(self::UUID,self::A_FILE_PATH, self::A_FILE_NAME);
 	}
 
 	public function test_FileWritten_put_shouldReturnTrue(){
 
 		$this->fileSystem->method('put')->willReturn(true);
 
-		$written = $this->s3mount->put(self::UUID,self::A_FILE_PATH);
+		$written = $this->s3mount->put(self::UUID,self::A_FILE_PATH, self::A_FILE_NAME);
 
 		$this->assertTrue($written);
 	}
@@ -222,7 +223,7 @@ class S3Test extends PHPUnit_Framework_TestCase{
 
 		$this->fileSystem->method('put')->willReturn(false);
 
-		$written = $this->s3mount->put(self::UUID,self::A_FILE_PATH);
+		$written = $this->s3mount->put(self::UUID,self::A_FILE_PATH, self::A_FILE_NAME);
 
 		$this->assertFalse($written);
 	}
@@ -239,7 +240,7 @@ class S3Test extends PHPUnit_Framework_TestCase{
 			->method('generatePath')
 			->with(self::UUID);
 
-		$this->s3mount->delete(self::UUID);
+		$this->s3mount->delete(self::UUID, self::A_FILE_NAME);
 	}
 
 	public function test_path_delete_shouldDeleteFile(){
@@ -250,14 +251,14 @@ class S3Test extends PHPUnit_Framework_TestCase{
 			->method('delete')
 			->with(self::A_PATH);
 
-		$this->s3mount->delete(self::UUID);
+		$this->s3mount->delete(self::UUID, self::A_FILE_NAME);
 	}
 
 	public function test_FileDeleted_delete_shouldReturnTrue(){
 
 		$this->fileSystem->method('delete')->willReturn(true);
 
-		$deleted = $this->s3mount->delete(self::UUID);
+		$deleted = $this->s3mount->delete(self::UUID, self::A_FILE_NAME);
 
 		$this->assertTrue($deleted);
 	}
@@ -266,7 +267,7 @@ class S3Test extends PHPUnit_Framework_TestCase{
 
 		$this->fileSystem->method('delete')->willReturn(false);
 
-		$deleted = $this->s3mount->delete(self::UUID);
+		$deleted = $this->s3mount->delete(self::UUID, self::A_FILE_NAME);
 
 		$this->assertFalse($deleted);
 	}
@@ -277,7 +278,7 @@ class S3Test extends PHPUnit_Framework_TestCase{
 			->method('generatePath')
 			->with(self::UUID);
 
-		$this->s3mount->getMetadata(self::UUID);
+		$this->s3mount->getMetadata(self::UUID, self::A_FILE_NAME);
 	}
 
 	public function test_path_getMetadata_shouldGetMetadata(){
@@ -288,14 +289,14 @@ class S3Test extends PHPUnit_Framework_TestCase{
 			->method('getMetadata')
 			->with(self::A_PATH);
 
-		$this->s3mount->getMetadata(self::UUID);
+		$this->s3mount->getMetadata(self::UUID, self::A_FILE_NAME);
 	}
 
 	public function test_Path_getMetadata_shouldReturnMetadata(){
 
 		$this->fileSystem->method('getMetadata')->willReturn(['timestamp'=>0,'mimetype'=>0]);
 
-		$metadata = $this->s3mount->getMetadata(self::UUID);
+		$metadata = $this->s3mount->getMetadata(self::UUID, self::A_FILE_NAME);
 
 		self::assertInstanceOf(Metadata::class,$metadata);
 	}
@@ -304,7 +305,7 @@ class S3Test extends PHPUnit_Framework_TestCase{
 
 		$this->fileSystem->method('getMetadata')->willReturn(false);
 
-		$metadata = $this->s3mount->getMetadata(self::UUID);
+		$metadata = $this->s3mount->getMetadata(self::UUID, self::A_FILE_NAME);
 
 		$this->assertFalse($metadata);
 	}
@@ -318,7 +319,7 @@ class S3Test extends PHPUnit_Framework_TestCase{
 			->expects(self::once())
 			->method('getClient');
 
-		$this->s3mount->retrieve(self::UUID);
+		$this->s3mount->retrieve(self::UUID, self::A_FILE_NAME);
 	}
 
 	public function test_uuid_retreive_shouldGetPathOfFile(){
@@ -330,7 +331,7 @@ class S3Test extends PHPUnit_Framework_TestCase{
 			->method('generatePath')
 			->with(self::UUID);
 
-		$this->s3mount->retrieve(self::UUID);
+		$this->s3mount->retrieve(self::UUID, self::A_FILE_NAME);
 	}
 
 	public function test_path_retreive_shouldGetFileLocation(){
@@ -343,7 +344,7 @@ class S3Test extends PHPUnit_Framework_TestCase{
 			->method('applyPathPrefix')
 			->with(self::A_PATH);
 
-		$this->s3mount->retrieve(self::UUID);
+		$this->s3mount->retrieve(self::UUID, self::A_FILE_NAME);
 	}
 
 	public function test_location_retreive_shouldRestoreObject(){
@@ -369,7 +370,7 @@ class S3Test extends PHPUnit_Framework_TestCase{
 			)
 			->willReturn($this->getMockWithoutInvokingTheOriginalConstructor(CommandInterface::class));
 
-		$this->s3mount->retrieve(self::UUID);
+		$this->s3mount->retrieve(self::UUID, self::A_FILE_NAME);
 	}
 
 	public function test_command_retreive_shouldExecuteCommand(){
@@ -382,7 +383,7 @@ class S3Test extends PHPUnit_Framework_TestCase{
 			->method('execute')
 			->with($command);
 
-		$this->s3mount->retrieve(self::UUID);
+		$this->s3mount->retrieve(self::UUID, self::A_FILE_NAME);
 	}
 
 	public function test_commandFailed_retreive_shouldCatchAndThrowNewException(){
@@ -393,7 +394,7 @@ class S3Test extends PHPUnit_Framework_TestCase{
 
 		self::expectException(CantRetreiveFileException::class);
 
-		$this->s3mount->retrieve(self::UUID);
+		$this->s3mount->retrieve(self::UUID, self::A_FILE_NAME);
 	}
 }
 


### PR DESCRIPTION
Il faut pouvoir travailler avec le nom du fichier vue qu'il fait officiellement partie du path chez amazon. À moins qu'il y aurait eu une autre façon que je n'ai pas pensé.