### PR TITLE
LIBS-140 Bybass a bug with finfo in php 7.4

### DIFF
--- a/Kronos/FileSystem/Mount/S3/AsyncAdapter.php
+++ b/Kronos/FileSystem/Mount/S3/AsyncAdapter.php
@@ -56,7 +56,7 @@ class AsyncAdapter
     {
         $options = $this->configTranslator->translate($this->mount->getConfig());
          if ( ! isset($options['ContentType'])) {
-            $options['ContentType'] = Util::guessMimeType($path, $content);
+            $options['ContentType'] = Util\MimeType::detectByFilename($path);
         }
 
         if ( ! isset($options['ContentLength'])) {

--- a/Kronos/FileSystem/Mount/S3/S3.php
+++ b/Kronos/FileSystem/Mount/S3/S3.php
@@ -15,7 +15,7 @@ use Kronos\FileSystem\Mount\PathGeneratorInterface;
 use Kronos\FileSystem\PromiseFactory;
 use League\Flysystem\AwsS3v3\AwsS3Adapter;
 use League\Flysystem\Filesystem;
-use League\Flysystem\Util;
+use League\Flysystem\Util\MimeType;
 
 class S3 extends FlySystemBaseMount
 {
@@ -172,6 +172,21 @@ class S3 extends FlySystemBaseMount
             });
     }
 
+    /**
+     * Write a new file using a stream.
+     *
+     * @param string $uuid
+     * @param string $filePath
+     * @param $fileName
+     * @return bool
+     */
+    public function put($uuid, $filePath, $fileName)
+    {
+        $path = $this->pathGenerator->generatePath($uuid, $fileName);
+        $mimeType = MimeType::detectByFilename($fileName);
+        return $this->mount->put($path, $this->getFileContent($filePath), ['ContentType' => $mimeType]);
+    }
+
     public function putAsync($uuid, $filePath, $fileName): PromiseInterface
     {
         $path = $this->pathGenerator->generatePath($uuid, $fileName);
@@ -181,6 +196,13 @@ class S3 extends FlySystemBaseMount
             ->then(function($response) {
                 return true;
             });
+    }
+
+    public function putStream($uuid, $stream, $fileName)
+    {
+        $path = $this->pathGenerator->generatePath($uuid, $fileName);
+        $mimeType = MimeType::detectByFilename($fileName);
+        return $this->mount->putStream($path, $stream, ['ContentType' => $mimeType]);
     }
 
     public function putStreamAsync($uuid, $stream, $fileName): PromiseInterface


### PR DESCRIPTION
The bug is in the AwsS3Adaptor which guess the MimeType / ContentType from the stream data. The underlying library used in PHP 7.4 uses a lot a ram and cause processes to reach the memory limit and get killed.