### PR TITLE
CRM-18047: create InvalidFilenameException

### DIFF
--- a/Kronos/FileSystem/Exception/InvalidFilenameException.php
+++ b/Kronos/FileSystem/Exception/InvalidFilenameException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Kronos\FileSystem\Exception;
+
+use Exception;
+
+class InvalidFilenameException extends Exception
+{
+    public function __construct(string $fileUuid, ?string $filename)
+    {
+        $filename = $filename === null ? 'null' : 'empty string';
+
+        parent::__construct(
+            sprintf(
+                'Filename of file with uuid %s must be a non-empty-string, %s given.',
+                $fileUuid,
+                $filename
+            )
+        );
+    }
+}

--- a/Kronos/FileSystem/FileRepositoryInterface.php
+++ b/Kronos/FileSystem/FileRepositoryInterface.php
@@ -2,12 +2,10 @@
 
 namespace Kronos\FileSystem;
 
-use Kronos\FileSystem\File\File;
-use Kronos\FileSystem\File\Metadata;
+use Kronos\FileSystem\Exception\InvalidFilenameException;
 
 interface FileRepositoryInterface
 {
-
     /**
      * @param string $mountType
      * @param string $fileName
@@ -24,6 +22,7 @@ interface FileRepositoryInterface
     /**
      * @param string $uuid
      * @return string
+     * @throws InvalidFilenameException
      */
     public function getFileName($uuid);
 


### PR DESCRIPTION
[CRM-18047](https://jira.equisoft.com/browse/CRM-18047)

Création d'une exception pour cette [PR](https://github.com/kronostechnologies/kronos-crm/pull/9306).

L'exception sera aussi utilisé pour les string vides par rapport au [commentaire](https://github.com/kronostechnologies/kronos-crm/pull/9306#issuecomment-1385852112) d'Eric:
```
Même les string vide sont un peu à risque à mon avis.
```

Et ajout de l'exception dans la phpDoc de l'interface `FileRepositoryInterface::getFileName()`