### PR TITLE
CRM-18070: Remove elao/enum dependency

### DIFF
--- a/Kronos/FileSystem/Mount/S3/AsyncAdapter.php
+++ b/Kronos/FileSystem/Mount/S3/AsyncAdapter.php
@@ -48,7 +48,7 @@ class AsyncAdapter
             unset($options['ContentLength']);
         }
 
-         $acl = $options[SupportedOptionsEnum::ACL] ?? 'private';
+         $acl = $options[SupportedOptionsEnum::ACL->value] ?? 'private';
 
          return $this->s3Client->uploadAsync(
             $this->s3Adapter->getBucket(),

--- a/Kronos/FileSystem/Mount/S3/ConfigToOptionsTranslator.php
+++ b/Kronos/FileSystem/Mount/S3/ConfigToOptionsTranslator.php
@@ -10,11 +10,11 @@ class ConfigToOptionsTranslator
     {
         $options = [];
 
-        $supportedOptions = SupportedOptionsEnum::values();
-        foreach($supportedOptions as $supportedOption) {
-            $value = $config->get((string)$supportedOption);
+        foreach (SupportedOptionsEnum::cases() as $supportedOption) {
+            $value = $config->get($supportedOption->value);
+
             if ($value !== null) {
-                $options[$supportedOption] = $value;
+                $options[$supportedOption->value] = $value;
             }
         }
 

--- a/Kronos/FileSystem/Mount/S3/SupportedOptionsEnum.php
+++ b/Kronos/FileSystem/Mount/S3/SupportedOptionsEnum.php
@@ -2,32 +2,27 @@
 
 namespace Kronos\FileSystem\Mount\S3;
 
-use Elao\Enum\AutoDiscoveredValuesTrait;
-use Elao\Enum\Enum;
-
-class SupportedOptionsEnum extends Enum
+enum SupportedOptionsEnum: string
 {
-    use AutoDiscoveredValuesTrait;
-
-    public const ACL = 'ACL';
-    public const CACHE_CONTROL = 'CacheControl';
-    public const CONTENT_DISPOSITION = 'ContentDisposition';
-    public const CONTENT_ENCODING = 'ContentEncoding';
-    public const CONTENT_LENGTH = 'ContentLength';
-    public const CONTENT_TYPE = 'ContentType';
-    public const EXPIRES = 'Expires';
-    public const GRANT_FULL_CONTROL = 'GrantFullControl';
-    public const GRANT_READ = 'GrantRead';
-    public const GRANT_READ_ACP = 'GrantReadACP';
-    public const GRANT_WRITE_ACP = 'GrantWriteACP';
-    public const METADATA = 'Metadata';
-    public const REQUEST_PAYER = 'RequestPayer';
-    public const SSE_CUSTOMER_ALGORITHM = 'SSECustomerAlgorithm';
-    public const SSE_CUSTOMER_KEY = 'SSECustomerKey';
-    public const SSE_CUSTOMER_KEY_MD5 = 'SSECustomerKeyMD5';
-    public const SSE_KMS_KEY_ID = 'SSEKMSKeyId';
-    public const SERVER_SIDE_ENCRYPTION = 'ServerSideEncryption';
-    public const STORAGE_CLASS = 'StorageClass';
-    public const TAGGING = 'Tagging';
-    public const WEBSITE_REDIRECT_LOCATION = 'WebsiteRedirectLocation';
+    case ACL = 'ACL';
+    case CACHE_CONTROL = 'CacheControl';
+    case CONTENT_DISPOSITION = 'ContentDisposition';
+    case CONTENT_ENCODING = 'ContentEncoding';
+    case CONTENT_LENGTH = 'ContentLength';
+    case CONTENT_TYPE = 'ContentType';
+    case EXPIRES = 'Expires';
+    case GRANT_FULL_CONTROL = 'GrantFullControl';
+    case GRANT_READ = 'GrantRead';
+    case GRANT_READ_ACP = 'GrantReadACP';
+    case GRANT_WRITE_ACP = 'GrantWriteACP';
+    case METADATA = 'Metadata';
+    case REQUEST_PAYER = 'RequestPayer';
+    case SSE_CUSTOMER_ALGORITHM = 'SSECustomerAlgorithm';
+    case SSE_CUSTOMER_KEY = 'SSECustomerKey';
+    case SSE_CUSTOMER_KEY_MD5 = 'SSECustomerKeyMD5';
+    case SSE_KMS_KEY_ID = 'SSEKMSKeyId';
+    case SERVER_SIDE_ENCRYPTION = 'ServerSideEncryption';
+    case STORAGE_CLASS = 'StorageClass';
+    case TAGGING = 'Tagging';
+    case WEBSITE_REDIRECT_LOCATION = 'WebsiteRedirectLocation';
 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
     "php": "^8.1",
     "league/flysystem": "^1",
     "league/flysystem-aws-s3-v3": "^1",
-    "elao/enum": "^1.12",
     "guzzlehttp/guzzle": "^7.5",
     "guzzlehttp/promises": "^1.5",
     "guzzlehttp/psr7": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "82ceac3eb878bb5cb73b495f5bb5edaf",
+    "content-hash": "1570639364e136b6a8bf16566218e716",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -149,90 +149,6 @@
                 "source": "https://github.com/aws/aws-sdk-php/tree/3.241.1"
             },
             "time": "2022-11-09T19:31:43+00:00"
-        },
-        {
-            "name": "elao/enum",
-            "version": "v1.12.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Elao/PhpEnums.git",
-                "reference": "373ecfa06f0568e7a2ffe68a46d6072a5127c6f4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Elao/PhpEnums/zipball/373ecfa06f0568e7a2ffe68a46d6072a5127c6f4",
-                "reference": "373ecfa06f0568e7a2ffe68a46d6072a5127c6f4",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.0"
-            },
-            "require-dev": {
-                "api-platform/core": "^2.5.1",
-                "doctrine/data-fixtures": "^1.2",
-                "doctrine/doctrine-bundle": "^1.4|^2.0",
-                "doctrine/orm": "^2.4",
-                "friendsofphp/php-cs-fixer": "^2.12.0",
-                "nelmio/alice": "^3.0",
-                "phpspec/prophecy": "~1.0",
-                "symfony/browser-kit": "^3.4|^4.4|^5.0",
-                "symfony/console": "^3.4|^4.4|^5.0",
-                "symfony/css-selector": "^3.4|^4.4|^5.0",
-                "symfony/form": "^3.4|^4.4|^5.0",
-                "symfony/framework-bundle": "^3.4|^4.4|^5.0",
-                "symfony/phpunit-bridge": "^3.4|^4.4|^5.0",
-                "symfony/serializer": "^3.4|^4.4|^5.0",
-                "symfony/translation": "^3.4|^4.4|^5.0",
-                "symfony/twig-bundle": "^3.4|^4.4|^5.0",
-                "symfony/validator": "^3.4|^4.4|^5.0",
-                "symfony/yaml": "^3.4|^4.4|^5.0"
-            },
-            "bin": [
-                "bin/elao-enum-dump-js"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Elao\\Enum\\": "src/"
-                },
-                "files": [
-                    "src/Bridge/Symfony/VarDumper/Resources/register_caster.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Elao",
-                    "homepage": "https://www.elao.com"
-                },
-                {
-                    "name": "Maxime Steinhausser",
-                    "email": "maxime.steinhausser@gmail.com",
-                    "homepage": "https://github.com/ogizanagi"
-                }
-            ],
-            "description": "Enumerations for PHP and frameworks integrations",
-            "homepage": "https://github.com/Elao/PhpEnums",
-            "keywords": [
-                "doctrine",
-                "enum",
-                "symfony"
-            ],
-            "funding": [
-                {
-                    "url": "https://github.com/ogizanagi",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-11-06T17:07:13+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/tests/Kronos/Tests/FileSystem/Mount/S3/AsyncAdapterTest.php
+++ b/tests/Kronos/Tests/FileSystem/Mount/S3/AsyncAdapterTest.php
@@ -6,7 +6,6 @@ use Aws\CommandInterface;
 use Aws\S3\Exception\S3Exception;
 use Aws\S3\S3Client;
 use GuzzleHttp\Promise\FulfilledPromise;
-use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7\Response;
@@ -206,7 +205,7 @@ class AsyncAdapterTest extends TestCase
 
     public function test_aclInOptions_upload_shouldSetAclToOptionsValue(): void
     {
-        $options = $this->givenOptions([SupportedOptionsEnum::ACL => self::PUBLIC_READ]);
+        $options = $this->givenOptions([SupportedOptionsEnum::ACL->value => self::PUBLIC_READ]);
         $this->givenFullSetup();
         $this->configToOptionsTranslator
             ->method('translate')
@@ -242,8 +241,8 @@ class AsyncAdapterTest extends TestCase
                 self::PRIVATE,
                 [
                     'params' => [
-                        SupportedOptionsEnum::CONTENT_TYPE => self::TEXT_PLAIN,
-                        SupportedOptionsEnum::CONTENT_LENGTH => strlen(self::CONTENTS),
+                        SupportedOptionsEnum::CONTENT_TYPE->value => self::TEXT_PLAIN,
+                        SupportedOptionsEnum::CONTENT_LENGTH->value => strlen(self::CONTENTS),
                     ]
                 ]
             );
@@ -501,7 +500,7 @@ class AsyncAdapterTest extends TestCase
         $promise = $this->asyncAdapter->has(self::PATH);
 
         $called = false;
-        $promise->then(null, function($reason) use (&$called) {
+        $promise->then(null, function($reason) use (&$called, $exception) {
             $called = true;
             self::assertSame($exception, $reason);
         });
@@ -564,8 +563,8 @@ class AsyncAdapterTest extends TestCase
     {
         return array_merge(
             [
-                SupportedOptionsEnum::CONTENT_TYPE => self::TEXT_PLAIN,
-                SupportedOptionsEnum::CONTENT_LENGTH => strlen(self::CONTENTS)
+                SupportedOptionsEnum::CONTENT_TYPE->value => self::TEXT_PLAIN,
+                SupportedOptionsEnum::CONTENT_LENGTH->value => strlen(self::CONTENTS)
             ],
             $options
         );

--- a/tests/Kronos/Tests/FileSystem/Mount/S3/ConfigToOptionsTranslatorTest.php
+++ b/tests/Kronos/Tests/FileSystem/Mount/S3/ConfigToOptionsTranslatorTest.php
@@ -28,14 +28,14 @@ class ConfigToOptionsTranslatorTest extends TestCase
 
     public function test_config_translate_shouldGetAllSupportedOptions(): void
     {
-        $supportedOptions = SupportedOptionsEnum::values();
+        $supportedOptions = SupportedOptionsEnum::cases();
         $this->config
             ->expects(self::exactly(count($supportedOptions)))
             ->method('get')
             ->withConsecutive(
                 ...array_map(
                     function ($option) {
-                        return [$option];
+                        return [$option->value];
                     },
                     $supportedOptions
                 )
@@ -50,14 +50,14 @@ class ConfigToOptionsTranslatorTest extends TestCase
             ->method('get')
             ->willReturnCallback(
                 function ($optionName) {
-                    return $optionName === SupportedOptionsEnum::STORAGE_CLASS ? self::STORAGE_CLASS_VALUE : null;
+                    return $optionName === SupportedOptionsEnum::STORAGE_CLASS->value ? self::STORAGE_CLASS_VALUE : null;
                 }
             );
 
         $options = $this->translator->translate($this->config);
 
         self::assertCount(1, $options);
-        self::assertArrayHasKey(SupportedOptionsEnum::STORAGE_CLASS, $options);
-        self::assertEquals(self::STORAGE_CLASS_VALUE, $options[SupportedOptionsEnum::STORAGE_CLASS]);
+        self::assertArrayHasKey(SupportedOptionsEnum::STORAGE_CLASS->value, $options);
+        self::assertEquals(self::STORAGE_CLASS_VALUE, $options[SupportedOptionsEnum::STORAGE_CLASS->value]);
     }
 }


### PR DESCRIPTION
Utiliser les enums PHP natifs pour remplacer l'update de renovate vers elao/enum v2 (#70).