### PR TITLE
dev/CRM-21238_hotfix throw WrongTypeException when directory given instead of file

### DIFF
--- a/Kronos/FileSystem/Exception/WrongTypeException.php
+++ b/Kronos/FileSystem/Exception/WrongTypeException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Kronos\FileSystem\Exception;
+
+use Exception;
+
+class WrongTypeException extends Exception
+{
+    public function __construct($expectedType, $actualTypeClass)
+    {
+        parent::__construct("Expected $expectedType but got $actualTypeClass");
+    }
+}

--- a/Kronos/FileSystem/FileSystem.php
+++ b/Kronos/FileSystem/FileSystem.php
@@ -205,7 +205,7 @@ class FileSystem implements FileSystemInterface
     {
         $mount = $this->getMountForId($id);
         $fileName = $this->fileRepository->getFileName($id);
-        return $mount->getUrl($id, $fileName, $this->shouldForceDownload($fileName));;
+        return $mount->getUrl($id, $fileName, $this->shouldForceDownload($fileName));
     }
 
     /**

--- a/Kronos/FileSystem/Mount/FlySystemBaseMount.php
+++ b/Kronos/FileSystem/Mount/FlySystemBaseMount.php
@@ -4,12 +4,13 @@ namespace Kronos\FileSystem\Mount;
 
 
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Promise\RejectedPromise;
 use Kronos\FileSystem\Exception\WrongFileSystemTypeException;
+use Kronos\FileSystem\Exception\WrongTypeException;
 use Kronos\FileSystem\File\File;
 use Kronos\FileSystem\PromiseFactory;
 use League\Flysystem\Filesystem;
 use Throwable;
+use TypeError;
 
 abstract class FlySystemBaseMount implements MountInterface
 {
@@ -68,13 +69,19 @@ abstract class FlySystemBaseMount implements MountInterface
      * @param string $uuid
      * @param $fileName
      * @return File
+     * @throws WrongTypeException
      */
     public function get($uuid, $fileName)
     {
         $path = $this->pathGenerator->generatePath($uuid, $fileName);
         /** @var \League\Flysystem\File $flySystemFile */
         $flySystemFile = $this->mount->get($path);
-        return new File($flySystemFile);
+        try {
+            $file = new File($flySystemFile);
+        } catch (TypeError) {
+            throw new WrongTypeException(File::class, get_class($flySystemFile));
+        }
+        return $file;
     }
 
     /**

--- a/tests/Kronos/Tests/FileSystem/FileSystemTest.php
+++ b/tests/Kronos/Tests/FileSystem/FileSystemTest.php
@@ -13,6 +13,7 @@ use Kronos\FileSystem\Copy\DestinationChooserFactory;
 use Kronos\FileSystem\Copy\Factory as CopyFactory;
 use Kronos\FileSystem\Exception\FileCantBeWrittenException;
 use Kronos\FileSystem\Exception\MountNotFoundException;
+use Kronos\FileSystem\Exception\WrongTypeException;
 use Kronos\FileSystem\ExtensionList;
 use Kronos\FileSystem\File\File;
 use Kronos\FileSystem\File\Internal\Metadata;
@@ -1159,6 +1160,16 @@ class FileSystemTest extends TestCase
         self::assertInstanceOf(File::class, $this->file);
     }
 
+    public function test_wrongTypeException_mountGet_shouldThrowException()
+    {
+        $this->givenWillThrowWrongTypeException();
+        $this->givenMountSelected();
+
+        $this->expectException(WrongTypeException::class);
+
+        $this->file = $this->fileSystem->get(self::UUID);
+    }
+
     public function test_copy_shouldGetFileMountType()
     {
         $this->givenMountSelected();
@@ -1728,6 +1739,14 @@ class FileSystemTest extends TestCase
         $this->mount->method('getMetadata')->willReturn($this->metadata);
         $this->file = $this->createMock(File::class);
         $this->mount->method('get')->willReturn($this->file);
+    }
+
+    private function givenWillThrowWrongTypeException()
+    {
+        $this->metadata = new Metadata();
+        $this->mount->method('getMetadata')->willReturn($this->metadata);
+        $this->file = $this->createMock(File::class);
+        $this->mount->method('get')->willThrowException(new WrongTypeException('expected', 'actual'));
     }
 
     protected function givenImporationMountType()

--- a/tests/Kronos/Tests/FileSystem/Mount/Local/LocalTest.php
+++ b/tests/Kronos/Tests/FileSystem/Mount/Local/LocalTest.php
@@ -6,11 +6,13 @@ use Exception;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\RejectedPromise;
+use Kronos\FileSystem\Exception\WrongTypeException;
 use Kronos\FileSystem\File\Internal\Metadata;
 use Kronos\FileSystem\PromiseFactory;
 use Kronos\FileSystem\Mount\PathGeneratorInterface;
 use League\Flysystem\Adapter\Local;
 use League\Flysystem\File;
+use League\Flysystem\Directory;
 use League\Flysystem\Filesystem;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -88,6 +90,21 @@ class LocalTest extends TestCase
     {
         $this->fileSystem->method('get')->willReturn($this->createMock(File::class));
         $this->pathGenerator->method('generatePath')->willReturn(self::A_PATH);
+
+        $this->fileSystem
+            ->expects(self::once())
+            ->method('get')
+            ->with(self::A_PATH);
+
+        $this->localMount->get(self::UUID, self::A_FILE_NAME);
+    }
+
+    public function test_getDirectory_shouldThrowException()
+    {
+        $this->fileSystem->method('get')->willReturn($this->createMock(Directory::class));
+        $this->pathGenerator->method('generatePath')->willReturn(self::A_PATH);
+
+        $this->expectException(WrongTypeException::class);
 
         $this->fileSystem
             ->expects(self::once())


### PR DESCRIPTION
CRM-21238
throw WrongTypeException when directory given instead of file

Je ne me sentais pas secure de faire un hotfix sur une version avec plein de pr de renovate